### PR TITLE
Remove legacy Slack references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Join Slack](https://img.shields.io/badge/Join%20us%20on-Slack-e01563.svg)](https://godaddy-oss-slack.herokuapp.com/)
 [![Build Status](https://travis-ci.com/godaddy/aws-liveness.svg?branch=master)](https://travis-ci.com/godaddy/aws-liveness) [![Greenkeeper badge](https://badges.greenkeeper.io/godaddy/aws-liveness.svg)](https://greenkeeper.io/)
 
 # aws-liveness


### PR DESCRIPTION
Contributions and questions should now be handled in GitHub Issues and Discussions.